### PR TITLE
Add Update and Forever

### DIFF
--- a/.github/workflows/codetests.yml
+++ b/.github/workflows/codetests.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: stable
       - name: go-test
         run: go test ./...
   # Runs golangci-lint on macos against freebsd and macos.
@@ -31,12 +31,12 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: stable
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.50
+          version: v1.59
   # Runs golangci-lint on linux against linux and windows.
   golangci-linux:
     strategy:
@@ -49,9 +49,9 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: stable
       - uses: actions/checkout@v4
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.50
+          version: v1.59

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,18 +1,10 @@
 linters:
   enable-all: true
   disable:
-    - maligned
-    - scopelint
-    - interfacer
-    - golint
-    - exhaustivestruct
+    - gomnd       # deprecated
+    - execinquery # deprecated
     - exhaustruct
     - nlreturn
-    - varcheck
-    - nosnakecase
-    - structcheck
-    - deadcode
-    - ifshort
     - rowserrcheck
     - sqlclosecheck
     - wastedassign

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ plug into expvar, or other metrics modules.
 
 This module has a concept of pruning. Items can be marked prunable,
 or not prunable. Those marked prunable are deleted after they have not
-had a `get` requst within a specified duration. Those marked not-prunable
+had a `get` request within a specified duration. Those marked not-prunable
 have a different configurable maximum unused age.
 
 I wrote this to cache data from mysql queries for an [nginx auth proxy](https://github.com/Notifiarr/mysql-auth-proxy).
+I've since began using it in plenty of other places as a global data store.
 See a simple example in [cache_test.go](cache_test.go).

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![discord](https://badgen.net/badge/icon/Discord?color=0011ff&label&icon=https://simpleicons.now.sh/discord/eee "GoLift Discord")](https://golift.io/discord)
 
 This go module provides a very simple in-memory key/value cache.
-It uses no mutex locks; utilizing only 1 go routine, 2 channels, 
-and 1 or 2 tickers depending on if you enable the pruner.
+It uses 1 mutex lock only during start and stop; utilizes only 1 go routine,
+2 channels, and 1 or 2 tickers depending on if you enable the pruner.
 The module also exports git/miss statistics that you can 
 plug into expvar, or other metrics modules.
 

--- a/cache.go
+++ b/cache.go
@@ -1,18 +1,24 @@
 package cache
 
-import "time"
+import (
+	"context"
+	"sync"
+	"time"
+)
 
 // Config provides the input options for a new cache.
 // All the fields are optional.
 type Config struct {
-	// Prune enables the pruner routine.
+	// PruneInterval enables the pruner routine and controls
+	// how often it checks every cache key and deletes those eligible.
 	// This must be enabled to use Expire time on Items.
 	// If you don't want other prunes to happen,
-	// set really long durations for PruneAfter and MaxUnused.
+	// set really long durations for PruneAfter and/or MaxUnused.
 	// @recommend 3 minutes - 5 minutes
 	PruneInterval time.Duration
 	// PruneAfter causes the pruner routine to prune keys marked prunable
 	// after they have not been used for this duration.
+	// Pass cache.Forever to never prune items marked prunable.
 	// @default 18 minutes
 	PruneAfter time.Duration
 	// Keys not marked prunable are pruned by the pruner routine
@@ -34,8 +40,10 @@ type Cache struct {
 	cache map[string]*Item
 	req   chan *req
 	res   chan *Item
+	run   bool
 	conf  *Config
 	stats Stats
+	mu    sync.Mutex // locks 'run' on Start() and Stop().
 }
 
 // Item is what's returned from a cache Get.
@@ -54,7 +62,7 @@ type Item struct {
 // Options are optional, and may be provided when saving a cached item.
 type Options struct {
 	// Setting Prune true will allow the pruning routine to prune this item.
-	// Items are pruned when they have not been retreived in the PruneAfter duration.
+	// Items are pruned when they have not been retrieved in the PruneAfter duration.
 	Prune bool
 	// You may set a specific eviction time for an item. This only works if the
 	// pruner is running. The item will be removed from cache after this date/time.
@@ -65,11 +73,12 @@ type Options struct {
 
 // Defaults.
 const (
-	defaultMaxUnused = 25 * time.Hour // Use cache.Forever to avoid expiring unused items.
-	defaultExpire    = 18 * time.Minute
+	defaultMaxUnused = 25 * time.Hour         // Use cache.Forever to avoid expiring unused items.
+	minimumPruneDur  = time.Second            // Not optimized for sub-second caches. (set PruneInterval)
+	defaultPruneDur  = 18 * time.Minute       // 18m is probably not what you want. (set PruneAfter if 0)
 	defaultAccuracy  = time.Second            // 1-5s is fine for most things.
-	minimumAccuracy  = 100 * time.Millisecond // minimum is 1/10th of a second.
-	maximumAccuracy  = time.Hour              // good for slow-use cache.
+	minimumAccuracy  = 100 * time.Millisecond // Minimum is 1/10th of a second.
+	maximumAccuracy  = time.Hour              // Good for slow-use cache.
 )
 
 const (
@@ -81,46 +90,71 @@ const (
 // New starts the cache routine and returns a struct to get data from the cache.
 // You do not need to call Start() after calling New(); it's already started.
 func New(config Config) *Cache {
-	cache := &Cache{conf: &config}
-	cache.checkPruneSettings()
-	cache.start()
+	return newWithContext(context.Background(), config)
+}
+
+// NewWithContext starts the cache routine and returns a struct to get data from the cache.
+// You do not need to call Start() after calling New(); it's already started.
+// If the context is cancelled or times out the cache processor exits.
+func NewWithContext(ctx context.Context, config Config) *Cache {
+	return newWithContext(ctx, config)
+}
+
+func newWithContext(ctx context.Context, config Config) *Cache {
+	cache := newCache(&config)
+	cache.start(ctx)
 
 	return cache
 }
 
-// checkPruneSettings runs once on startup.
-func (c *Cache) checkPruneSettings() {
+// newCache runs once from New() and turns a *Config into a *Cache you can Start().
+func newCache(conf *Config) *Cache {
 	switch {
-	case c.conf.RequestAccuracy == 0:
-		c.conf.RequestAccuracy = defaultAccuracy
-	case c.conf.RequestAccuracy < minimumAccuracy:
-		c.conf.RequestAccuracy = minimumAccuracy
-	case c.conf.RequestAccuracy > maximumAccuracy:
-		c.conf.RequestAccuracy = maximumAccuracy
+	case conf.RequestAccuracy == 0:
+		conf.RequestAccuracy = defaultAccuracy
+	case conf.RequestAccuracy < minimumAccuracy:
+		conf.RequestAccuracy = minimumAccuracy
+	case conf.RequestAccuracy > maximumAccuracy:
+		conf.RequestAccuracy = maximumAccuracy
 	}
 
-	if c.conf.PruneInterval == 0 {
-		return
+	if conf.PruneInterval != 0 && conf.PruneInterval < minimumPruneDur {
+		conf.PruneInterval = minimumPruneDur
 	}
 
-	if c.conf.PruneInterval < time.Second {
-		c.conf.PruneInterval = time.Second
+	// If prune interval is 0, PruneAfter does not control anything.
+	if conf.PruneAfter == 0 {
+		conf.PruneAfter = defaultPruneDur
 	}
 
-	if c.conf.PruneAfter == 0 {
-		c.conf.PruneAfter = defaultExpire
+	// If prune interval is 0, MaxUnused does not control anything.
+	if conf.MaxUnused == 0 {
+		conf.MaxUnused = defaultMaxUnused
 	}
 
-	if c.conf.MaxUnused == 0 {
-		c.conf.MaxUnused = defaultMaxUnused
-	}
+	return &Cache{conf: conf}
 }
 
-// Starts sets up the cache and starts the go routine.
+// Start sets up the cache and starts the go routine using a Background context.
 // Call this only if you already called Stop() and wish to turn it back on.
 // Setting clean will clear the existing cache before restarting.
 func (c *Cache) Start(clean bool) {
-	if c.req != nil {
+	c.startWithContext(context.Background(), clean)
+}
+
+// StartWithContext sets up the cache and starts the go routine with a context.
+// Call this only if you already called Stop() and wish to turn it back on.
+// Setting clean will clear the existing cache before restarting.
+// If the context is cancelled or times out the cache processor exits.
+func (c *Cache) StartWithContext(ctx context.Context, clean bool) {
+	c.startWithContext(ctx, clean)
+}
+
+func (c *Cache) startWithContext(ctx context.Context, clean bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.run {
 		return // already running, nothing to start.
 	}
 
@@ -128,13 +162,20 @@ func (c *Cache) Start(clean bool) {
 		c.clean()
 	}
 
-	c.start()
+	c.start(ctx)
 }
 
 // Stop stops the go routine and closes the channels.
 // If clean is true it will clean up memory usage and delete the cache.
 // Pass clean if the app will continue to run, and you don't need to re-use the cache data.
 func (c *Cache) Stop(clean bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if !c.run {
+		return // not running, nothing to stop.
+	}
+
 	c.stop()
 
 	if clean {
@@ -143,40 +184,46 @@ func (c *Cache) Stop(clean bool) {
 }
 
 // Get returns a pointer to a copy of an item, or nil if it doesn't exist.
-// Because it's a copy, concurrent access is OK.
+// This library will not read or write to the item after it's returned.
+// Calling this procedure after calling Stop() or cancelling the context produces a panic.
 func (c *Cache) Get(requestKey string) *Item {
 	c.req <- &req{key: requestKey, get: true}
 	return <-c.res
 }
 
 // Save saves an item, and returns true if it already existed (got updated).
-// This procedure does NOT update hit/miss stats like Get() does.
+// This procedure does NOT update hit/miss stats like cache.Get() does.
+// Calling this procedure after calling Stop() or cancelling the context produces a panic.
 func (c *Cache) Save(requestKey string, data any, opts Options) bool {
 	c.req <- &req{key: requestKey, data: data, opts: &opts}
 	return <-c.res != nil
 }
 
 // Update saves an item, and returns a copy of the previously saved item.
-// This procedure updates hit/miss stats like Get() does.
+// If you do not need the previous item, use cache.Save() instead.
+// This procedure updates hit/miss stats like cache.Get() does.
 // Check the item for nil to determine if it existed prior to this call.
+// Calling this procedure after calling Stop() or cancelling the context produces a panic.
 func (c *Cache) Update(requestKey string, data any, opts Options) *Item {
 	c.req <- &req{key: requestKey, get: true, data: data, opts: &opts}
 	return <-c.res
 }
 
 // Delete removes an item and returns true if it existed.
+// Calling this procedure after calling Stop() or cancelling the context produces a panic.
 func (c *Cache) Delete(requestKey string) bool {
 	c.req <- &req{key: requestKey}
 	return <-c.res != nil
 }
 
-// List returns a copy of the in-memory cache.
-// This will never be nil, and concurrent access is OK.
-// The map Items will also never be nil, and because they
-// are copies, concurrent access to Items is also OK.
+// List returns a copy of the in-memory cache. The map list will never be nil.
+// This library will not read or write to the map after it's returned.
+// The map Items will also never be nil, and because they are copies,
+// this library will not read or write to them after they're returned.
 // This method will double the memory footprint until release, and garbage collection runs.
 // If the data stored in cache is large and not pointers, then you may
 // not want to call this method much, or at all.
+// Calling this procedure after calling Stop() or cancelling the context produces a panic.
 func (c *Cache) List() map[string]*Item {
 	c.req <- &req{list: true}
 	items, _ := (<-c.res).Data.(map[string]*Item)

--- a/processor.go
+++ b/processor.go
@@ -1,6 +1,9 @@
 package cache
 
-import "time"
+import (
+	"context"
+	"time"
+)
 
 // req is our request (input channel data).
 type req struct {
@@ -12,22 +15,21 @@ type req struct {
 	opts *Options
 }
 
-func (c *Cache) start() {
+func (c *Cache) start(ctx context.Context) {
 	if c.cache == nil {
 		c.cache = make(map[string]*Item)
 	}
 
 	c.req = make(chan *req)
 	c.res = make(chan *Item)
+	c.run = true
 
-	go c.processRequests()
+	go c.processRequests(ctx)
 }
 
 func (c *Cache) stop() {
 	close(c.req)
-	<-c.res
-	c.req = nil
-	c.res = nil
+	<-c.res // wait for it to close.
 }
 
 // clean it up and free some memory.
@@ -43,49 +45,60 @@ func (c *Cache) clean() {
 }
 
 // processRequests readies and starts the main go routine for the cache.
-func (c *Cache) processRequests() {
-	defer close(c.res) // close response channel when request channel closes.
-
+func (c *Cache) processRequests(ctx context.Context) {
 	pruner := &time.Ticker{}
 	if c.conf.PruneInterval > 0 {
 		pruner = time.NewTicker(c.conf.PruneInterval)
-		defer pruner.Stop()
 	}
 
 	timer := time.NewTicker(c.conf.RequestAccuracy)
-	defer timer.Stop()
 
-	// this only returns when Stop() is called.
-	c.processor(time.Now(), pruner, timer)
+	defer func() {
+		timer.Stop()
+		pruner.Stop()
+		close(c.res) // close response channel when request channel closes.
+		c.run = false
+	}()
+
+	// This only returns when Stop() is called or the context is Done.
+	c.processor(ctx, time.Now(), pruner, timer)
 }
 
 // processor is the single go routine in this module for request processing.
-//
-//nolint:cyclop // processor has to be "complicated" to do the job.
-func (c *Cache) processor(now time.Time, pruner, timer *time.Ticker) {
+func (c *Cache) processor(ctx context.Context, now time.Time, pruner, timer *time.Ticker) {
 	for {
 		select {
+		case <-ctx.Done():
+			close(c.req)
+			return
 		case now = <-timer.C: // usually 1 second to 1 minute, max 1 hour.
 			// Update `now` with a ticker to avoid slow time.Now() calls during request processing.
 		case req, ok := <-c.req:
-			switch {
-			case !ok:
-				return
-			case req.data != nil:
-				c.res <- c.save(req, now, req.get)
-			case req.get:
-				c.res <- c.get(req.key, now)
-			case req.list:
-				c.res <- c.list()
-			case req.stat:
-				c.res <- &Item{Data: c.stats, Hits: int64(len(c.cache))}
-			default:
-				c.res <- c.delete(req.key)
+			if !ok {
+				return // Stop() called. Shutting down!
 			}
+
+			c.process(now, req)
 		case now = <-pruner.C: // usually a few minutes (ticker).
 			c.prune(&now)
 			c.stats.Pruning.Duration += time.Since(now)
 		}
+	}
+}
+
+// process a request from the processor().
+func (c *Cache) process(now time.Time, req *req) {
+	switch {
+	case req.data != nil:
+		c.res <- c.save(req, now, req.get)
+	case req.get:
+		c.res <- c.get(req.key, now)
+	case req.list:
+		c.res <- c.list()
+	case req.stat:
+		c.res <- &Item{Data: c.stats, Hits: int64(len(c.cache))}
+	default:
+		c.res <- c.delete(req.key)
 	}
 }
 


### PR DESCRIPTION
- Updates linter rules and version.
- Adds `Update()` method that combines `Get()` and `Save()`.
- Adds a `Forever` time.Duration constant that can be passed into `MaxUnused`.
- Renames a few private variables for easier readability.
- Increases maximum request accuracy from one minute to one hour.
- Provides a context input so the processor can be cancelled without calling `Stop()`.
- It will now panic if a CRUD method is called after `Stop()` is called. Instead of deadlock.