### PR TITLE
Extend API with new Get methods.

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -267,11 +267,11 @@ func (c *Cache) Save(requestKey string, data any, opts Options) bool {
 	shard.mu.Lock()
 	defer shard.mu.Unlock()
 
-	return shard.save(requestKey, data, opts, now, false) != nil
+	return shard.save(requestKey, data, opts, now)
 }
 
 // Update saves an item, and returns a copy of the previously saved item.
-// If you do not need the previous item, use cache.Save() instead.
+// If you do not need the previous item, use Save() instead (no prior snapshot allocation).
 // This procedure updates hit/miss stats like cache.Get() does.
 // Check the item for nil to determine if it existed prior to this call.
 // Calling this procedure after calling Stop() or cancelling the context produces a panic.
@@ -284,7 +284,7 @@ func (c *Cache) Update(requestKey string, data any, opts Options) *Item {
 	shard.mu.Lock()
 	defer shard.mu.Unlock()
 
-	return shard.save(requestKey, data, opts, now, true)
+	return shard.update(requestKey, data, opts, now)
 }
 
 // Delete removes an item and returns true if it existed.

--- a/cache.go
+++ b/cache.go
@@ -69,6 +69,7 @@ type Cache struct {
 //
 // Items held inside the cache use atomics for Hits/last access so Get can use a read lock;
 // values returned from Get and List are snapshots with plain fields.
+// GetInto copies those snapshot fields into caller memory.
 type Item struct {
 	Data any       `json:"data"`
 	Time time.Time `json:"created"`
@@ -210,6 +211,50 @@ func (c *Cache) Get(requestKey string) *Item {
 	return shard.get(requestKey, c.cachedNow())
 }
 
+// GetInto fills dst with the same snapshot fields that Get would return (Data, Time, Last, Hits).
+// It returns false if the key is missing and does not modify dst in that case.
+// It panics if dst is nil.
+//
+// Reuse dst across calls to avoid allocating a new *Item on each hit. Data is still the same
+// shallow reference as in the cache; do not mutate it in place if other goroutines may read
+// the cached value.
+//
+// Calling this procedure after calling Stop() or cancelling the context produces a panic.
+func (c *Cache) GetInto(requestKey string, dst *Item) bool {
+	if dst == nil {
+		panic("cache: GetInto with nil *Item")
+	}
+
+	c.areWeRunning()
+
+	shard := c.shardFor(requestKey)
+
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
+
+	return shard.getInto(requestKey, c.cachedNow(), dst)
+}
+
+// GetRaw returns the stored value (Item.Data) for the key. The second result is false if the key
+// is missing. If the key exists and Data is nil, it returns (nil, true).
+// It updates hit/miss statistics the same way as Get.
+//
+// The returned value is the same reference held in the cache; after this method returns, other
+// goroutines may replace or remove the entry or mutate mutable values pointed to by Data.
+// For a detached copy use Get; to fill caller-owned memory without allocating a new *Item use GetInto.
+//
+// Calling this procedure after calling Stop() or cancelling the context produces a panic.
+func (c *Cache) GetRaw(requestKey string) (any, bool) {
+	c.areWeRunning()
+
+	shard := c.shardFor(requestKey)
+
+	shard.mu.RLock()
+	defer shard.mu.RUnlock()
+
+	return shard.getRaw(requestKey, c.cachedNow())
+}
+
 // Save saves an item, and returns true if it already existed (got updated).
 // This procedure does NOT update hit/miss stats like cache.Get() does.
 // Calling this procedure after calling Stop() or cancelling the context produces a panic.
@@ -274,7 +319,7 @@ func (c *Cache) List() map[string]*Item {
 		shard.mu.RLock()
 
 		for key, item := range shard.items {
-			out[key] = item.copy()
+			out[key] = item.copy(nil) // nil means makes new *Items's.
 		}
 
 		shard.mu.RUnlock()

--- a/cache_ops_test.go
+++ b/cache_ops_test.go
@@ -17,6 +17,9 @@ const originalData = "original"
 // testHello is a shared payload for Get/GetInto/GetRaw tests (goconst).
 const testHello = "hello"
 
+// testUpdatedValue is used by Update tests (goconst).
+const testUpdatedValue = "new"
+
 // assertEqual is a tiny typed helper to avoid a testify dependency.
 func assertEqual[T comparable](t *testing.T, name string, want, got T) {
 	t.Helper()
@@ -470,7 +473,7 @@ func TestUpdate_NewKey(t *testing.T) {
 	store := cache.New(cache.Config{})
 	defer store.Stop(true)
 
-	prev := store.Update("k", "new", cache.Options{})
+	prev := store.Update("k", testUpdatedValue, cache.Options{})
 	if prev != nil {
 		t.Fatalf("Update new key: expected nil, got %+v", prev)
 	}
@@ -487,7 +490,7 @@ func TestUpdate_ExistingKey(t *testing.T) {
 
 	store.Save("k", originalData, cache.Options{})
 
-	prev := store.Update("k", "new", cache.Options{})
+	prev := store.Update("k", testUpdatedValue, cache.Options{})
 	if prev == nil {
 		t.Fatal("Update existing key: expected previous item, got nil")
 	}
@@ -502,8 +505,8 @@ func TestUpdate_ExistingKey(t *testing.T) {
 	assertEqual(t, "Hits", int64(1), stats.Hits)
 
 	item := store.Get("k")
-	if item == nil || item.Data != "new" {
-		t.Fatalf("after Update expected 'new', got %v", item)
+	if item == nil || item.Data != testUpdatedValue {
+		t.Fatalf("after Update expected %q, got %v", testUpdatedValue, item)
 	}
 }
 

--- a/cache_ops_test.go
+++ b/cache_ops_test.go
@@ -14,6 +14,9 @@ import (
 // originalData is used by several tests that save and retrieve the same string.
 const originalData = "original"
 
+// testHello is a shared payload for Get/GetInto/GetRaw tests (goconst).
+const testHello = "hello"
+
 // assertEqual is a tiny typed helper to avoid a testify dependency.
 func assertEqual[T comparable](t *testing.T, name string, want, got T) {
 	t.Helper()
@@ -301,15 +304,15 @@ func TestGet(t *testing.T) {
 		t.Fatalf("Get miss: expected nil, got %+v", got)
 	}
 
-	store.Save("k", "hello", cache.Options{})
+	store.Save("k", testHello, cache.Options{})
 
 	item := store.Get("k")
 	if item == nil {
 		t.Fatal("Get hit: expected item, got nil")
 	}
 
-	if item.Data != "hello" {
-		t.Fatalf("Get hit: expected 'hello', got %v", item.Data)
+	if item.Data != testHello {
+		t.Fatalf("Get hit: expected %q, got %v", testHello, item.Data)
 	}
 
 	if item.Hits != 1 {
@@ -319,6 +322,104 @@ func TestGet(t *testing.T) {
 	item2 := store.Get("k")
 	if item2.Hits != 2 {
 		t.Fatalf("Get hit #2: expected Hits=2, got %d", item2.Hits)
+	}
+}
+
+func TestGetInto(t *testing.T) {
+	t.Parallel()
+
+	store := cache.New(cache.Config{})
+	defer store.Stop(true)
+
+	var dst cache.Item
+	dst.Data = "should-not-appear-on-miss"
+
+	if store.GetInto("missing", &dst) {
+		t.Fatal("GetInto miss: expected false")
+	}
+
+	if dst.Data != "should-not-appear-on-miss" {
+		t.Fatalf("GetInto miss: expected dst unchanged, got Data=%v", dst.Data)
+	}
+
+	store.Save("k", testHello, cache.Options{})
+
+	if !store.GetInto("k", &dst) {
+		t.Fatal("GetInto hit: expected true")
+	}
+
+	if dst.Data != testHello || dst.Hits != 1 {
+		t.Fatalf("GetInto hit: got Data=%v Hits=%d", dst.Data, dst.Hits)
+	}
+
+	if !store.GetInto("k", &dst) || dst.Hits != 2 {
+		t.Fatalf("GetInto hit #2: expected Hits=2, got Hits=%d Data=%v", dst.Hits, dst.Data)
+	}
+
+	// Same stats as Get for the same operations.
+	stats := store.Stats()
+	assertEqual(t, "Hits", int64(2), stats.Hits)
+	assertEqual(t, "Misses", int64(1), stats.Misses)
+}
+
+func TestGetInto_nilPanics(t *testing.T) {
+	t.Parallel()
+
+	store := cache.New(cache.Config{})
+	defer store.Stop(true)
+
+	defer func() {
+		if recover() == nil {
+			t.Fatal("expected panic for nil *Item")
+		}
+	}()
+
+	store.GetInto("k", nil)
+}
+
+func TestGetRaw(t *testing.T) {
+	t.Parallel()
+
+	store := cache.New(cache.Config{})
+	defer store.Stop(true)
+
+	if _, ok := store.GetRaw("missing"); ok {
+		t.Fatal("GetRaw miss: expected ok false")
+	}
+
+	store.Save("k", testHello, cache.Options{})
+
+	raw, ok := store.GetRaw("k")
+	if !ok {
+		t.Fatal("GetRaw hit: expected ok true")
+	}
+
+	if raw != testHello {
+		t.Fatalf("GetRaw: want %q, got %v", testHello, raw)
+	}
+
+	raw2, ok2 := store.GetRaw("k")
+	if !ok2 || raw2 != raw {
+		t.Fatalf("GetRaw 2nd hit: want same value and ok, got %v %v", raw2, ok2)
+	}
+
+	stats := store.Stats()
+	assertEqual(t, "Hits", int64(2), stats.Hits)
+
+	snap := store.Get("k")
+	if snap == nil || snap.Hits != 3 {
+		t.Fatalf("after 2x GetRaw + Get expected Hits=3 on snapshot, got %+v", snap)
+	}
+
+	store.Save("nilval", nil, cache.Options{})
+
+	gotNil, okNil := store.GetRaw("nilval")
+	if !okNil {
+		t.Fatal("GetRaw stored nil: expected ok true")
+	}
+
+	if gotNil != nil {
+		t.Fatalf("GetRaw stored nil: want nil Data, got %v", gotNil)
 	}
 }
 

--- a/processor.go
+++ b/processor.go
@@ -82,12 +82,23 @@ func (c *Cache) backgroundLoop(ctx context.Context) {
 }
 
 // copy an item so it can be returned to the caller.
+// If dst is nil, a new Item is allocated and returned.
+// Otherwise, the fields are copied into the existing Item.
 // Do not call this with a nil Item.
-func (i *Item) copy() *Item {
-	return &Item{
-		Data: i.Data,
-		Time: i.Time,
-		Last: time.Unix(0, i.last.Load()),
-		Hits: i.hits.Load(),
+func (src *Item) copy(dst *Item) *Item {
+	if dst == nil {
+		return &Item{
+			Data: src.Data,
+			Time: src.Time,
+			Last: time.Unix(0, src.last.Load()),
+			Hits: src.hits.Load(),
+		}
 	}
+
+	dst.Data = src.Data
+	dst.Time = src.Time
+	dst.Last = time.Unix(0, src.last.Load())
+	dst.Hits = src.hits.Load()
+
+	return dst
 }

--- a/shard.go
+++ b/shard.go
@@ -32,7 +32,38 @@ func (s *shard) get(key string, now time.Time) *Item {
 	item.hits.Add(1)
 	item.last.Store(now.UnixNano())
 
-	return item.copy()
+	return item.copy(nil) // nil means makes new *Item's.
+}
+
+// getInto records a hit and fills dst with a snapshot of the item. Caller must hold s.mu for reading.
+func (s *shard) getInto(key string, now time.Time, dst *Item) bool {
+	item := s.items[key]
+	if item == nil {
+		s.misses.Add(1)
+		return false
+	}
+
+	s.hits.Add(1)
+	item.hits.Add(1)
+	item.last.Store(now.UnixNano())
+	item.copy(dst) // copy the cached item into the caller's *Item.
+
+	return true
+}
+
+// getRaw records a hit and returns the stored Data for the key. Caller must hold s.mu for reading.
+func (s *shard) getRaw(key string, now time.Time) (any, bool) {
+	item := s.items[key]
+	if item == nil {
+		s.misses.Add(1)
+		return nil, false
+	}
+
+	s.hits.Add(1)
+	item.hits.Add(1)
+	item.last.Store(now.UnixNano())
+
+	return item.Data, true
 }
 
 func placeItem(item *Item, data any, opts Options, now time.Time) *Item {
@@ -63,7 +94,7 @@ func (s *shard) save(key string, data any, opts Options, now time.Time, replace 
 		s.hits.Add(1)
 		item.hits.Add(1)
 		item.last.Store(now.UnixNano())
-		out := item.copy() // get stats before updating the item.
+		out := item.copy(nil) // get stats before updating the item. nil means makes new *Item
 		placeItem(item, data, opts, now)
 
 		return out

--- a/shard.go
+++ b/shard.go
@@ -20,6 +20,13 @@ type shard struct {
 	pruned  atomic.Int64
 }
 
+// bumpLookupHit records a successful lookup (same counters as a cache Get hit). Caller must hold s.mu.
+func (s *shard) bumpLookupHit(item *Item, now time.Time) {
+	s.hits.Add(1)
+	item.hits.Add(1)
+	item.last.Store(now.UnixNano())
+}
+
 // get returns a copy of an item. Caller must hold sh.mu for reading (RLock) or writing (Lock).
 func (s *shard) get(key string, now time.Time) *Item {
 	item := s.items[key]
@@ -28,9 +35,7 @@ func (s *shard) get(key string, now time.Time) *Item {
 		return nil
 	}
 
-	s.hits.Add(1)
-	item.hits.Add(1)
-	item.last.Store(now.UnixNano())
+	s.bumpLookupHit(item, now)
 
 	return item.copy(nil) // nil means makes new *Item's.
 }
@@ -43,9 +48,7 @@ func (s *shard) getInto(key string, now time.Time, dst *Item) bool {
 		return false
 	}
 
-	s.hits.Add(1)
-	item.hits.Add(1)
-	item.last.Store(now.UnixNano())
+	s.bumpLookupHit(item, now)
 	item.copy(dst) // copy the cached item into the caller's *Item.
 
 	return true
@@ -59,9 +62,7 @@ func (s *shard) getRaw(key string, now time.Time) (any, bool) {
 		return nil, false
 	}
 
-	s.hits.Add(1)
-	item.hits.Add(1)
-	item.last.Store(now.UnixNano())
+	s.bumpLookupHit(item, now)
 
 	return item.Data, true
 }
@@ -77,39 +78,39 @@ func placeItem(item *Item, data any, opts Options, now time.Time) *Item {
 	return item // send it back out for chaining.
 }
 
-// save stores an item. Caller must hold sh.mu (write lock).
-func (s *shard) save(key string, data any, opts Options, now time.Time, replace bool) *Item {
-	item := s.items[key] // Get existing item out of the map.
-
-	if replace { // Replace the existing item (update request).
-		if item == nil {
-			s.misses.Add(1)
-			s.saves.Add(1)
-			s.items[key] = placeItem(&Item{}, data, opts, now)
-
-			return nil
-		}
-
-		s.updates.Add(1)
-		s.hits.Add(1)
-		item.hits.Add(1)
-		item.last.Store(now.UnixNano())
-		out := item.copy(nil) // get stats before updating the item. nil means makes new *Item
-		placeItem(item, data, opts, now)
-
-		return out
-	}
-
+// save inserts or overwrites without changing get hit/miss counters. Returns true if the key
+// already existed. Caller must hold s.mu (write lock).
+func (s *shard) save(key string, data any, opts Options, now time.Time) bool {
+	item := s.items[key]
 	if item == nil {
 		s.saves.Add(1)
 		s.items[key] = placeItem(&Item{}, data, opts, now)
 
-		return nil
+		return false
 	}
 
 	s.updates.Add(1)
+	placeItem(item, data, opts, now)
 
-	return placeItem(item, data, opts, now)
+	return true
+}
+
+// update replaces the value for key. For a new key it counts a get miss plus a save and returns nil.
+// For an existing key it applies the same lookup accounting as get(), returns a detached copy of
+// the entry as it was after that accounting, then stores the new value. Caller must hold s.mu.
+func (s *shard) update(key string, data any, opts Options, now time.Time) *Item {
+	item := s.get(key, now)
+	if item == nil {
+		s.saves.Add(1)                                     // record stats for new item.
+		s.items[key] = placeItem(&Item{}, data, opts, now) // add new item to the shard.
+
+		return nil
+	}
+
+	s.updates.Add(1)                         // record stats for update.
+	placeItem(s.items[key], data, opts, now) // update the item in the shard.
+
+	return item
 }
 
 // delete removes a key. Caller must hold sh.mu (write lock).


### PR DESCRIPTION
- cache: Adds new `GetRaw()` method that returns the cached item directly without an `&Item{}` wrapper.
- cache: Adds new `GetInto()` method that allows the caller to provide their own `&Item{}`.  sync.Map? sure..
- cache: Both methods avoid the extra `&Item{}` allocation that `Get()` has.
- cache: Removes `&Item{}` allocation from `Save()`. It only returns a boolean after all.
- shard: Refactors the ugly store method into `save()` and `update()`. 
- shard: Adds a new counter abstraction method to make the code considerably cleaner.